### PR TITLE
sort not allowed in py3 from ordered dictionary

### DIFF
--- a/php/ng/files/php.ini
+++ b/php/ng/files/php.ini
@@ -5,7 +5,7 @@
 {{ section }} = {{ settings }}
             {%- else %}
 [{{ section }}]
-                {%- for setting in settings|sort -%}
+                {%- for setting in settings -%}
                     {%- for key, value in setting.items() %}
                         {%- if value is number or value is string %}
     {{ key }} = {{ value }}


### PR DESCRIPTION
https://github.com/saltstack-formulas/php-formula/pull/150/commits/57d1ecd7cc51402acff3076de85508e9dfae4e34